### PR TITLE
Add strip_from_keys option. Allow client config options and shared credentials

### DIFF
--- a/lib/puppet/functions/hiera_aws_sm.rb
+++ b/lib/puppet/functions/hiera_aws_sm.rb
@@ -74,17 +74,13 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
 
     result = nil
 
-    # Return cached key / value if present
-    if context.cache_has_key(key)
-      context.explain { "[hiera-aws-sm] Returning #{key} from cache" }
-      result = context.cached_value(key)
-    end
-
     # Query SecretsManager for the secret data, stopping once we find a match
     if result.nil?
       keys.each do |secret_key|
         result = get_secret(secret_key, options, context)
-        unless result.nil?    
+        unless result.nil?
+          context.explain { "[hiera-aws-sm] Caching key #{key}" }
+          context.cache(key, result)
           break
         end
       end
@@ -95,10 +91,6 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
     if result.nil? and continue_if_not_found
       context.not_found
     end
-
-    # Cache key / value
-    context.explain { "[hiera-aws-sm] Caching #{key}" }
-    context.cache(key, result)
 
     result
   end
@@ -117,6 +109,12 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
   # it is returned directly. If secret_string is set, and can be co-erced
   # into a Hash, it is returned, otherwise a String is returned.
   def get_secret(key, options, context)
+    # Return Cached Value if Present
+    if context.cache_has_key(key)
+      context.explain { "[hiera-aws-sm] Returning #{key} from cache..." }
+      return context.cached_value(key)
+    end
+
     # Allow Client Config Options Hash. Default to Empty Hash for Backwards Compatibility
     client_opts = options.key?('aws_client_options') ? options['aws_client_options'].transform_keys(&:to_sym) : {}
 

--- a/lib/puppet/functions/hiera_aws_sm.rb
+++ b/lib/puppet/functions/hiera_aws_sm.rb
@@ -106,6 +106,8 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
     # Allow Client Config Options Hash. Default to Empty Hash for Backwards Compatibility
     client_opts = options.key?('aws_client_options') ? options['aws_client_options'].transform_keys(&:to_sym) : {}
 
+    # Allow Credential Loading From External File (Allowing for Easier Credential Rotation Outside of Puppet as Needed)
+    # ref: https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb
     if options.key?('shared_credentials')
       client_opts[:credentials] = Aws::SharedCredentials.new(options['shared_credentials'].transform_keys(&:to_sym))
     else

--- a/lib/puppet/functions/hiera_aws_sm.rb
+++ b/lib/puppet/functions/hiera_aws_sm.rb
@@ -79,8 +79,8 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
       keys.each do |secret_key|
         result = get_secret(secret_key, options, context)
         unless result.nil?
-          context.explain { "[hiera-aws-sm] Caching key #{key}" }
-          context.cache(key, result)
+          context.explain { "[hiera-aws-sm] Caching key #{secret_key}" }
+          context.cache(secret_key, result)
           break
         end
       end

--- a/lib/puppet/functions/hiera_aws_sm.rb
+++ b/lib/puppet/functions/hiera_aws_sm.rb
@@ -46,6 +46,15 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
       end
     end
 
+    # Optional patterns to strip from keys prior to lookup
+    if strip_from_keys = options['strip_from_keys']
+      raise ArgumentError, '[hiera-aws-sm] strip_from_keys must be an array' unless strip_from_keys.is_a?(Array)
+
+      strip_from_keys.each do |prefix|
+        key = key.gsub(Regexp.new(prefix), '')
+      end
+    end
+
     # Handle prefixes if suplied
     if prefixes = options['prefixes']
       raise ArgumentError, '[hiera-aws-sm] prefixes must be an array' unless prefixes.is_a?(Array)

--- a/lib/puppet/functions/hiera_aws_sm.rb
+++ b/lib/puppet/functions/hiera_aws_sm.rb
@@ -55,7 +55,7 @@ Puppet::Functions.create_function(:hiera_aws_sm) do
       end
     end
 
-    # Handle prefixes if suplied
+    # Handle prefixes if supplied
     if prefixes = options['prefixes']
       raise ArgumentError, '[hiera-aws-sm] prefixes must be an array' unless prefixes.is_a?(Array)
       if delimiter = options['delimiter']


### PR DESCRIPTION
- Add new option to strip prefix(es) from keys as needed, similar to the vault module [here](https://github.com/petems/petems-hiera_vault/blob/master/README.md?plain=1#L149-L154)
- Allow arbitrary client config options to be passed in as a hash (backwards compatible with previous default)
- Enable shared credentials file to be managed outside of the module by specifying a shared credentials file and profile to be used instead of an access key and secret key (which enables for easier credential rotation)
- Enable caching